### PR TITLE
chore: refactor Jest configuration to allow `verbatimModuleSyntax`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,4 @@
-import { JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm', // or other ESM presets
@@ -9,4 +9,4 @@ const jestConfig: JestConfigWithTsJest = {
   projects: ['<rootDir>/packages/plainjs', '<rootDir>/packages/node', '<rootDir>/packages/whatwg'],
 };
 
-export default jestConfig;
+export = jestConfig;

--- a/packages/node/jest.config.ts
+++ b/packages/node/jest.config.ts
@@ -1,4 +1,4 @@
-import { JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
   extensionsToTreatAsEsm: ['.ts'],
@@ -15,4 +15,4 @@ const jestConfig: JestConfigWithTsJest = {
   setupFilesAfterEnv: ['<rootDir>/test/utils/setup.ts']
 }
 
-export default jestConfig;
+export = jestConfig;

--- a/packages/plainjs/jest.config.ts
+++ b/packages/plainjs/jest.config.ts
@@ -1,11 +1,17 @@
-import { JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
-  preset: 'ts-jest/presets/default-esm', // or other ESM presets
+  extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: { '^(\\.{1,2}/.*)\\.js$': '$1' },
+  transform: {
+    '^.+\\.m?[t]sx?$': ['ts-jest', {
+      isolatedModules: true,
+      useESM: true
+    }],
+  },
   testEnvironment: 'node',
   testMatch: ['<rootDir>/**/test/*.ts', '<rootDir>/**/test/types/*.ts'],
   collectCoverageFrom: ['src/**'],
 };
 
-export default jestConfig;
+export = jestConfig;

--- a/packages/whatwg/jest.config.ts
+++ b/packages/whatwg/jest.config.ts
@@ -1,4 +1,4 @@
-import { JestConfigWithTsJest } from 'ts-jest';
+import type { JestConfigWithTsJest } from 'ts-jest';
 
 const jestConfig: JestConfigWithTsJest = {
   extensionsToTreatAsEsm: ['.ts'],
@@ -15,4 +15,4 @@ const jestConfig: JestConfigWithTsJest = {
   setupFilesAfterEnv: ['<rootDir>/test/utils/setup.ts']
 }
 
-export default jestConfig;
+export = jestConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     /* Interop Constraints */
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    // "verbatimModuleSyntax": true,
+    "verbatimModuleSyntax": true,
     /* Type Checking */
     "allowUnreachableCode": false,
     // "exactOptionalPropertyTypes": true,
@@ -30,9 +30,7 @@
     "preserveConstEnums": true,
     "strict": true,
     /* Projects */
-    "incremental": true,
+    "incremental": true
   },
-  "include": [
-    "src/**/*.ts"
-  ]
+  "include": ["**/src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,4 @@
 {
-  "ts-node": {
-    "moduleTypes": {
-      "jest.config.ts": "cjs"
-    }
-  },
   "compilerOptions": {
     /* Language and Environment */
     "target": "es6",


### PR DESCRIPTION
Fixes #27

For reference see TypeScript [documentation](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax): 

> With [the `verbatimModuleSyntax`] option, what you see is what you get.
>
> That does have some implications when it comes to module interop though. Under this flag, ECMAScript `import`s and `export`s won’t be rewritten to `require` calls when your settings or file extension implied a different module system. Instead, you’ll get an error. If you need to emit code that uses `require` and `module.exports`, you’ll have to use TypeScript’s module syntax that predates ES2015

The syntax in this PR follows the one seen in the documentation. That is the change needed to allow `verbatimModuleSyntax: true`. If you really need it.