### PR TITLE
Fixed misnamed import in first whatwg example

### DIFF
--- a/packages/whatwg/README.md
+++ b/packages/whatwg/README.md
@@ -10,7 +10,7 @@ Fast dependency-free library to parse a JSON stream using utf-8 encoding in Node
 *tldr;*
 
 ```javascript
-import { JSONParser } from '@streamparser/json-what';
+import { JSONParser } from '@streamparser/json-whatwg';
 
 const inputStream = new ReadableStream({
   async start(controller) {


### PR DESCRIPTION
Hi,
The first example tries to import `import { JSONParser } from '@streamparser/json-what';` but it should be `import { JSONParser } from '@streamparser/json-whatwg';`.