### PR TITLE
Introduce support for optimistic parsing

### DIFF
--- a/packages/plainjs/README.md
+++ b/packages/plainjs/README.md
@@ -265,6 +265,59 @@ parser.onError = console.error;
 parser.write('"""');
 ```
 
+## Optimistic parsing
+
+Optimistic parsing can be useful when incrementally building a JSON value that
+you expect to be "eventually valid". When parsing optimistically, the parser
+will always make accessible its "best guess" at what the eventually-correct
+parsed value will look like. For example:
+
+```
+import { OptimisticJSONParser } from "@streamparser/json"
+
+const parser = new OptimisticJSONParser()
+
+parser.write('{')
+console.log(parser.value) // {}
+
+parser.write('"')
+console.log(parser.value) // {}
+
+parser.write('a"')
+console.log(parser.value) // { a: undefined }
+
+parser.write(': "b')
+console.log(parser.value) // { a: "b" }
+
+parser.write('ar", ')
+console.log(parser.value) // { a: "bar" }
+
+parser.write('"c":')
+console.log(parser.value) // { a: "bar", c: undefined }
+
+parser.write('[{')
+console.log(parser.value) // { a: "bar", c: [ {} ] }
+
+parser.write('"d')
+console.log(parser.value) // { a: "bar", c: [ { d: undefined } ] }
+
+parser.write('": 1')
+console.log(parser.value) // { a: "bar", c: [ { d: 1 } ] }
+
+parser.write('23')
+console.log(parser.value) // { a: "bar", c: [ { d: 123 } ] }
+
+parser.write('}')
+console.log(parser.value) // { a: "bar", c: [ { d: 123 } ] }
+```
+
+and so on. An optimistic parser will attempt to present incomplete null,
+boolean, string and number literals. It will also optimistically insert keys
+with as-yet-undefied values, and close opened objects and arrays. Under
+the hood, an optimistic tokenizer will emit "incomplete" tokens when it
+thinks that it will eventually reach a state where a token can be definitively
+produced.
+
 ## Examples
 
 ### Stream-parsing a fetch request returning a JSONstream

--- a/packages/plainjs/dist/deno/optimistic/index.ts
+++ b/packages/plainjs/dist/deno/optimistic/index.ts
@@ -1,0 +1,4 @@
+export * from "./jsonparser.ts";
+export * from "./tokenizer.ts";
+export * from "./tokenparser.ts";
+export * from "./types.ts";

--- a/packages/plainjs/dist/deno/optimistic/jsonparser.ts
+++ b/packages/plainjs/dist/deno/optimistic/jsonparser.ts
@@ -1,0 +1,64 @@
+import type { TokenizerOptions } from "../tokenizer.ts";
+import type { TokenParserOptions } from "../tokenparser.ts";
+import type { JsonStruct } from "../utils/types/jsonTypes.ts";
+import type { ParsedTokenInfo } from "../utils/types/parsedTokenInfo.ts";
+import { OptimisticTokenizer } from "./tokenizer.ts";
+import { OptimisticTokenParser } from "./tokenparser.ts";
+
+export interface OptimisticJSONParserOptions
+  extends TokenizerOptions,
+    TokenParserOptions {}
+
+export class OptimisticJSONParser {
+  private tokenizer: OptimisticTokenizer;
+  private tokenParser: OptimisticTokenParser;
+
+  constructor(opts: OptimisticJSONParserOptions = {}) {
+    this.tokenizer = new OptimisticTokenizer(opts);
+    this.tokenParser = new OptimisticTokenParser(opts);
+
+    this.tokenizer.onToken = this.tokenParser.write.bind(this.tokenParser);
+    this.tokenizer.onEnd = () => {
+      if (!this.tokenParser.isEnded) this.tokenParser.end();
+    };
+
+    this.tokenParser.onError = this.tokenizer.error.bind(this.tokenizer);
+    this.tokenParser.onEnd = () => {
+      if (!this.tokenizer.isEnded) this.tokenizer.end();
+    };
+  }
+
+  public get isEnded(): boolean {
+    return this.tokenizer.isEnded && this.tokenParser.isEnded;
+  }
+
+  public write(input: Iterable<number> | string): void {
+    this.tokenizer.write(input);
+  }
+
+  public end(): void {
+    this.tokenizer.end();
+  }
+
+  public set onToken(cb: (parsedTokenInfo: ParsedTokenInfo) => void) {
+    this.tokenizer.onToken = (parsedToken) => {
+      cb(parsedToken);
+      this.tokenParser.write(parsedToken);
+    };
+  }
+
+  public get value(): JsonStruct | undefined {
+    return this.tokenParser.value;
+  }
+
+  public set onError(cb: (err: Error) => void) {
+    this.tokenizer.onError = cb;
+  }
+
+  public set onEnd(cb: () => void) {
+    this.tokenParser.onEnd = () => {
+      if (!this.tokenizer.isEnded) this.tokenizer.end();
+      cb.call(this.tokenParser);
+    };
+  }
+}

--- a/packages/plainjs/dist/deno/optimistic/tokenizer.ts
+++ b/packages/plainjs/dist/deno/optimistic/tokenizer.ts
@@ -1,0 +1,788 @@
+import {
+  BufferedString,
+  NonBufferedString,
+  type StringBuilder,
+} from "../utils/bufferedString.ts";
+import TokenType from "../utils/types/tokenType.ts";
+import { charset, escapedSequences } from "../utils/utf-8.ts";
+import type { OptimisticParsedTokenInfo } from "./types.ts";
+
+// Tokenizer States
+const enum OptimisticTokenizerStates {
+  START,
+  ENDED,
+  ERROR,
+  TRUE1,
+  TRUE2,
+  TRUE3,
+  FALSE1,
+  FALSE2,
+  FALSE3,
+  FALSE4,
+  NULL1,
+  NULL2,
+  NULL3,
+  STRING_DEFAULT,
+  STRING_AFTER_BACKSLASH,
+  STRING_UNICODE_DIGIT_1,
+  STRING_UNICODE_DIGIT_2,
+  STRING_UNICODE_DIGIT_3,
+  STRING_UNICODE_DIGIT_4,
+  STRING_INCOMPLETE_CHAR,
+  NUMBER_AFTER_INITIAL_MINUS,
+  NUMBER_AFTER_INITIAL_ZERO,
+  NUMBER_AFTER_INITIAL_NON_ZERO,
+  NUMBER_AFTER_FULL_STOP,
+  NUMBER_AFTER_DECIMAL,
+  NUMBER_AFTER_E,
+  NUMBER_AFTER_E_AND_SIGN,
+  NUMBER_AFTER_E_AND_DIGIT,
+  SEPARATOR,
+}
+
+function OptimisticTokenizerStateToString(
+  tokenizerState: OptimisticTokenizerStates
+): string {
+  return [
+    "START",
+    "ENDED",
+    "ERROR",
+    "TRUE1",
+    "TRUE2",
+    "TRUE3",
+    "FALSE1",
+    "FALSE2",
+    "FALSE3",
+    "FALSE4",
+    "NULL1",
+    "NULL2",
+    "NULL3",
+    "STRING_DEFAULT",
+    "STRING_AFTER_BACKSLASH",
+    "STRING_UNICODE_DIGIT_1",
+    "STRING_UNICODE_DIGIT_2",
+    "STRING_UNICODE_DIGIT_3",
+    "STRING_UNICODE_DIGIT_4",
+    "STRING_INCOMPLETE_CHAR",
+    "NUMBER_AFTER_INITIAL_MINUS",
+    "NUMBER_AFTER_INITIAL_ZERO",
+    "NUMBER_AFTER_INITIAL_NON_ZERO",
+    "NUMBER_AFTER_FULL_STOP",
+    "NUMBER_AFTER_DECIMAL",
+    "NUMBER_AFTER_E",
+    "NUMBER_AFTER_E_AND_SIGN",
+    "NUMBER_AFTER_E_AND_DIGIT",
+    "SEPARATOR",
+  ][tokenizerState];
+}
+
+export interface OptimisticTokenizerOptions {
+  stringBufferSize?: number;
+  numberBufferSize?: number;
+  separator?: string;
+}
+
+const defaultOpts: OptimisticTokenizerOptions = {
+  stringBufferSize: 0,
+  numberBufferSize: 0,
+  separator: undefined,
+};
+
+export class OptimisticTokenizerError extends Error {
+  constructor(message: string) {
+    super(message);
+    // Typescript is broken. This is a workaround
+    Object.setPrototypeOf(this, OptimisticTokenizerError.prototype);
+  }
+}
+
+export class OptimisticTokenizer {
+  private state = OptimisticTokenizerStates.START;
+
+  private separator?: string;
+  private separatorBytes?: Uint8Array;
+  private separatorIndex = 0;
+  private bufferedString: StringBuilder;
+  private bufferedNumber: StringBuilder;
+
+  private unicode?: string; // unicode escapes
+  private highSurrogate?: number;
+  private bytes_remaining = 0; // number of bytes remaining in multi byte utf8 char to read after split boundary
+  private bytes_in_sequence = 0; // bytes in multi byte utf8 char to read
+  private char_split_buffer = new Uint8Array(4); // for rebuilding chars split before boundary is reached
+  private encoder = new TextEncoder();
+  private offset = -1;
+
+  constructor(opts?: OptimisticTokenizerOptions) {
+    opts = { ...defaultOpts, ...opts };
+
+    this.bufferedString =
+      opts.stringBufferSize && opts.stringBufferSize > 4
+        ? new BufferedString(opts.stringBufferSize)
+        : new NonBufferedString();
+    this.bufferedNumber =
+      opts.numberBufferSize && opts.numberBufferSize > 0
+        ? new BufferedString(opts.numberBufferSize)
+        : new NonBufferedString();
+
+    this.separator = opts.separator;
+    this.separatorBytes = opts.separator
+      ? this.encoder.encode(opts.separator)
+      : undefined;
+  }
+
+  public get isEnded(): boolean {
+    return this.state === OptimisticTokenizerStates.ENDED;
+  }
+
+  public write(input: Iterable<number> | string): void {
+    try {
+      let buffer: Uint8Array;
+      if (input instanceof Uint8Array) {
+        buffer = input;
+      } else if (typeof input === "string") {
+        buffer = this.encoder.encode(input);
+      } else if (
+        (typeof input === "object" && "buffer" in input) ||
+        Array.isArray(input)
+      ) {
+        buffer = Uint8Array.from(input);
+      } else {
+        throw new TypeError(
+          "Unexpected type. The `write` function only accepts Arrays, TypedArrays and Strings."
+        );
+      }
+
+      for (let i = 0; i < buffer.length; i += 1) {
+        const n = buffer[i];
+
+        switch (this.state) {
+          case OptimisticTokenizerStates.START:
+            this.offset += 1;
+
+            if (this.separatorBytes && n === this.separatorBytes[0]) {
+              if (this.separatorBytes.length === 1) {
+                this.state = OptimisticTokenizerStates.START;
+                this.onToken({
+                  token: TokenType.SEPARATOR,
+                  value: this.separator as string,
+                  offset: this.offset + this.separatorBytes.length - 1,
+                  type: "complete",
+                });
+                continue;
+              }
+              this.state = OptimisticTokenizerStates.SEPARATOR;
+              continue;
+            }
+
+            if (
+              n === charset.SPACE ||
+              n === charset.NEWLINE ||
+              n === charset.CARRIAGE_RETURN ||
+              n === charset.TAB
+            ) {
+              // whitespace
+              continue;
+            }
+
+            if (n === charset.LEFT_CURLY_BRACKET) {
+              this.onToken({
+                token: TokenType.LEFT_BRACE,
+                value: "{",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.RIGHT_CURLY_BRACKET) {
+              this.onToken({
+                token: TokenType.RIGHT_BRACE,
+                value: "}",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.LEFT_SQUARE_BRACKET) {
+              this.onToken({
+                token: TokenType.LEFT_BRACKET,
+                value: "[",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.RIGHT_SQUARE_BRACKET) {
+              this.onToken({
+                token: TokenType.RIGHT_BRACKET,
+                value: "]",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.COLON) {
+              this.onToken({
+                token: TokenType.COLON,
+                value: ":",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.COMMA) {
+              this.onToken({
+                token: TokenType.COMMA,
+                value: ",",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_T) {
+              this.state = OptimisticTokenizerStates.TRUE1;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_F) {
+              this.state = OptimisticTokenizerStates.FALSE1;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_N) {
+              this.state = OptimisticTokenizerStates.NULL1;
+              continue;
+            }
+
+            if (n === charset.QUOTATION_MARK) {
+              this.bufferedString.reset();
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+
+            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state =
+                OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO;
+              continue;
+            }
+
+            if (n === charset.DIGIT_ZERO) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO;
+              continue;
+            }
+
+            if (n === charset.HYPHEN_MINUS) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_MINUS;
+              continue;
+            }
+
+            break;
+          // STRING
+          case OptimisticTokenizerStates.STRING_DEFAULT:
+            if (n === charset.QUOTATION_MARK) {
+              const string = this.bufferedString.toString();
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.STRING,
+                value: string,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += this.bufferedString.byteLength + 1;
+              continue;
+            }
+
+            if (n === charset.REVERSE_SOLIDUS) {
+              this.state = OptimisticTokenizerStates.STRING_AFTER_BACKSLASH;
+              continue;
+            }
+
+            if (n >= 128) {
+              // Parse multi byte (>=128) chars one at a time
+              if (n >= 194 && n <= 223) {
+                this.bytes_in_sequence = 2;
+              } else if (n <= 239) {
+                this.bytes_in_sequence = 3;
+              } else {
+                this.bytes_in_sequence = 4;
+              }
+
+              if (this.bytes_in_sequence <= buffer.length - i) {
+                // if bytes needed to complete char fall outside buffer length, we have a boundary split
+                this.bufferedString.appendBuf(
+                  buffer,
+                  i,
+                  i + this.bytes_in_sequence
+                );
+                i += this.bytes_in_sequence - 1;
+                continue;
+              }
+
+              this.bytes_remaining = i + this.bytes_in_sequence - buffer.length;
+              this.char_split_buffer.set(buffer.subarray(i));
+              i = buffer.length - 1;
+              this.state = OptimisticTokenizerStates.STRING_INCOMPLETE_CHAR;
+              continue;
+            }
+
+            if (n >= charset.SPACE) {
+              this.bufferedString.appendChar(n);
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.STRING_INCOMPLETE_CHAR:
+            // check for carry over of a multi byte char split between data chunks
+            // & fill temp buffer it with start of this data chunk up to the boundary limit set in the last iteration
+            this.char_split_buffer.set(
+              buffer.subarray(i, i + this.bytes_remaining),
+              this.bytes_in_sequence - this.bytes_remaining
+            );
+            this.bufferedString.appendBuf(
+              this.char_split_buffer,
+              0,
+              this.bytes_in_sequence
+            );
+            i = this.bytes_remaining - 1;
+            this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+            continue;
+          case OptimisticTokenizerStates.STRING_AFTER_BACKSLASH: {
+            const controlChar = escapedSequences[n];
+            if (controlChar) {
+              this.bufferedString.appendChar(controlChar);
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.unicode = "";
+              this.state = OptimisticTokenizerStates.STRING_UNICODE_DIGIT_1;
+              continue;
+            }
+
+            break;
+          }
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_1:
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_2:
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_3:
+            if (
+              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+              (n >= charset.LATIN_CAPITAL_LETTER_A &&
+                n <= charset.LATIN_CAPITAL_LETTER_F) ||
+              (n >= charset.LATIN_SMALL_LETTER_A &&
+                n <= charset.LATIN_SMALL_LETTER_F)
+            ) {
+              this.unicode += String.fromCharCode(n);
+              this.state += 1;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_4:
+            if (
+              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+              (n >= charset.LATIN_CAPITAL_LETTER_A &&
+                n <= charset.LATIN_CAPITAL_LETTER_F) ||
+              (n >= charset.LATIN_SMALL_LETTER_A &&
+                n <= charset.LATIN_SMALL_LETTER_F)
+            ) {
+              const intVal = parseInt(
+                this.unicode + String.fromCharCode(n),
+                16
+              );
+              if (this.highSurrogate === undefined) {
+                if (intVal >= 0xd800 && intVal <= 0xdbff) {
+                  // <55296,56319> - highSurrogate
+                  this.highSurrogate = intVal;
+                } else {
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(String.fromCharCode(intVal))
+                  );
+                }
+              } else {
+                if (intVal >= 0xdc00 && intVal <= 0xdfff) {
+                  // <56320,57343> - lowSurrogate
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(
+                      String.fromCharCode(this.highSurrogate, intVal)
+                    )
+                  );
+                } else {
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(String.fromCharCode(this.highSurrogate))
+                  );
+                }
+                this.highSurrogate = undefined;
+              }
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+            break;
+          // Number
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_MINUS:
+            if (n === charset.DIGIT_ZERO) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO;
+              continue;
+            }
+
+            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state =
+                OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+            if (n === charset.FULL_STOP) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP;
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            if (n === charset.FULL_STOP) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP;
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          case OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+
+          // @ts-ignore fallthrough
+          case OptimisticTokenizerStates.NUMBER_AFTER_E:
+            if (n === charset.PLUS_SIGN || n === charset.HYPHEN_MINUS) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E_AND_SIGN;
+              continue;
+            }
+          case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_SIGN:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          // TRUE
+          case OptimisticTokenizerStates.TRUE1:
+            if (n === charset.LATIN_SMALL_LETTER_R) {
+              this.state = OptimisticTokenizerStates.TRUE2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.TRUE2:
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.state = OptimisticTokenizerStates.TRUE3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.TRUE3:
+            if (n === charset.LATIN_SMALL_LETTER_E) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.TRUE,
+                value: true,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 3;
+              continue;
+            }
+            break;
+          // FALSE
+          case OptimisticTokenizerStates.FALSE1:
+            if (n === charset.LATIN_SMALL_LETTER_A) {
+              this.state = OptimisticTokenizerStates.FALSE2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE2:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.FALSE3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE3:
+            if (n === charset.LATIN_SMALL_LETTER_S) {
+              this.state = OptimisticTokenizerStates.FALSE4;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE4:
+            if (n === charset.LATIN_SMALL_LETTER_E) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.FALSE,
+                value: false,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 4;
+              continue;
+            }
+            break;
+          // NULL
+          case OptimisticTokenizerStates.NULL1:
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.state = OptimisticTokenizerStates.NULL2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.NULL2:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.NULL3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.NULL3:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.NULL,
+                value: null,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.SEPARATOR:
+            this.separatorIndex += 1;
+            if (
+              !this.separatorBytes ||
+              n !== this.separatorBytes[this.separatorIndex]
+            ) {
+              break;
+            }
+            if (this.separatorIndex === this.separatorBytes.length - 1) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.SEPARATOR,
+                value: this.separator as string,
+                offset: this.offset + this.separatorIndex,
+                type: "complete",
+              });
+              this.separatorIndex = 0;
+            }
+            continue;
+          case OptimisticTokenizerStates.ENDED:
+            if (
+              n === charset.SPACE ||
+              n === charset.NEWLINE ||
+              n === charset.CARRIAGE_RETURN ||
+              n === charset.TAB
+            ) {
+              // whitespace
+              continue;
+            }
+        }
+
+        throw new OptimisticTokenizerError(
+          `Unexpected "${String.fromCharCode(
+            n
+          )}" at position "${i}" in state ${OptimisticTokenizerStateToString(
+            this.state
+          )}`
+        );
+      }
+
+      switch (this.state) {
+        case OptimisticTokenizerStates.TRUE1:
+        case OptimisticTokenizerStates.TRUE2:
+        case OptimisticTokenizerStates.TRUE3:
+          this.onToken({
+            token: TokenType.TRUE,
+            value: true,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.FALSE1:
+        case OptimisticTokenizerStates.FALSE2:
+        case OptimisticTokenizerStates.FALSE3:
+        case OptimisticTokenizerStates.FALSE4:
+          this.onToken({
+            token: TokenType.FALSE,
+            value: false,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.NULL1:
+        case OptimisticTokenizerStates.NULL2:
+        case OptimisticTokenizerStates.NULL3:
+          this.onToken({
+            token: TokenType.NULL,
+            value: null,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.STRING_DEFAULT: {
+          const string = this.bufferedString.toString();
+          this.onToken({
+            token: TokenType.STRING,
+            value: string,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        }
+        case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+        case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+        case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+        case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+          this.onToken({
+            token: TokenType.NUMBER,
+            value: this.parseNumber(this.bufferedNumber.toString()),
+            offset: this.offset,
+            type: "incomplete",
+          });
+      }
+    } catch (err: any) {
+      this.error(err);
+    }
+  }
+
+  private emitNumber(): void {
+    this.onToken({
+      token: TokenType.NUMBER,
+      value: this.parseNumber(this.bufferedNumber.toString()),
+      offset: this.offset,
+      type: "complete",
+    });
+    this.offset += this.bufferedNumber.byteLength - 1;
+  }
+
+  protected parseNumber(numberStr: string): number {
+    return Number(numberStr);
+  }
+
+  public error(err: Error): void {
+    if (this.state !== OptimisticTokenizerStates.ENDED) {
+      this.state = OptimisticTokenizerStates.ERROR;
+    }
+
+    this.onError(err);
+  }
+
+  public end(): void {
+    switch (this.state) {
+      case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+      case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+      case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+      case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+        this.state = OptimisticTokenizerStates.ENDED;
+        this.emitNumber();
+        this.onEnd();
+        break;
+      case OptimisticTokenizerStates.START:
+      case OptimisticTokenizerStates.ERROR:
+      case OptimisticTokenizerStates.SEPARATOR:
+        this.state = OptimisticTokenizerStates.ENDED;
+        this.onEnd();
+        break;
+      default:
+        this.error(
+          new OptimisticTokenizerError(
+            `Tokenizer ended in the middle of a token (state: ${OptimisticTokenizerStateToString(
+              this.state
+            )}). Either not all the data was received or the data was invalid.`
+          )
+        );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onToken(parsedToken: OptimisticParsedTokenInfo): void {
+    // Override me
+    throw new OptimisticTokenizerError(
+      'Can\'t emit tokens before the "onToken" callback has been set up.'
+    );
+  }
+
+  public onError(err: Error): void {
+    // Override me
+    throw err;
+  }
+
+  public onEnd(): void {
+    // Override me
+  }
+}

--- a/packages/plainjs/dist/deno/optimistic/tokenparser.ts
+++ b/packages/plainjs/dist/deno/optimistic/tokenparser.ts
@@ -1,0 +1,296 @@
+import type {
+  JsonArray,
+  JsonKey,
+  JsonObject,
+  JsonStruct,
+} from "../utils/types/jsonTypes.ts";
+import { TokenParserMode } from "../utils/types/stackElement.ts";
+import TokenType from "../utils/types/tokenType.ts";
+import type { OptimisticParsedTokenInfo } from "./types.ts";
+
+// Parser States
+const enum OptimisticTokenParserState {
+  VALUE,
+  KEY,
+  COLON,
+  COMMA,
+  ENDED,
+  ERROR,
+  SEPARATOR,
+}
+
+function TokenParserStateToString(state: OptimisticTokenParserState): string {
+  return ["VALUE", "KEY", "COLON", "COMMA", "ENDED", "ERROR", "SEPARATOR"][
+    state
+  ];
+}
+
+export interface OptimisticTokenParserOptions {
+  separator?: string;
+}
+
+export interface OptimisticStackElement {
+  key: JsonKey;
+  value: JsonStruct;
+  mode?: TokenParserMode;
+}
+
+const defaultOpts: OptimisticTokenParserOptions = {
+  separator: undefined,
+};
+
+export class OptimisticTokenParserError extends Error {
+  constructor(message: string) {
+    super(message);
+    // Typescript is broken. This is a workaround
+    Object.setPrototypeOf(this, OptimisticTokenParserError.prototype);
+  }
+}
+
+export class OptimisticTokenParser {
+  private readonly separator?: string;
+  private state: OptimisticTokenParserState = OptimisticTokenParserState.VALUE;
+  private mode: TokenParserMode | undefined = undefined;
+  private key: JsonKey = undefined;
+  private currentValue: JsonStruct | undefined = undefined;
+  public value: JsonStruct | undefined = undefined;
+  private stack: OptimisticStackElement[] = [];
+
+  constructor(opts?: OptimisticTokenParserOptions) {
+    opts = { ...defaultOpts, ...opts };
+
+    this.separator = opts.separator;
+  }
+
+  private push(): void {
+    this.stack.push({
+      key: this.key,
+      value: this.currentValue as JsonStruct,
+      mode: this.mode,
+    });
+  }
+
+  private pop(): void {
+    ({
+      key: this.key,
+      value: this.currentValue,
+      mode: this.mode,
+    } = this.stack.pop() as OptimisticStackElement);
+
+    this.state =
+      this.mode !== undefined
+        ? OptimisticTokenParserState.COMMA
+        : OptimisticTokenParserState.VALUE;
+
+    this.checkIfEnded();
+  }
+
+  private checkIfEnded(): void {
+    if (this.stack.length === 0) {
+      if (this.separator) {
+        this.state = OptimisticTokenParserState.SEPARATOR;
+      } else if (this.separator === undefined) {
+        this.end();
+      }
+      // else if separator === '', expect next JSON object.
+    }
+  }
+
+  public get isEnded(): boolean {
+    return this.state === OptimisticTokenParserState.ENDED;
+  }
+
+  private setStateIfComplete(
+    state: OptimisticTokenParserState,
+    type: "complete" | "incomplete",
+  ): void {
+    if (type === "complete") {
+      this.state = state;
+    }
+  }
+
+  private setCurrentValue(value: JsonStruct): void {
+    if (this.value === undefined) {
+      this.value = value;
+    }
+
+    this.currentValue = value;
+  }
+
+  public write({
+    token,
+    value,
+    type,
+  }: Omit<OptimisticParsedTokenInfo, "offset">): void {
+    try {
+      if (this.state === OptimisticTokenParserState.VALUE) {
+        if (
+          token === TokenType.STRING ||
+          token === TokenType.NUMBER ||
+          token === TokenType.TRUE ||
+          token === TokenType.FALSE ||
+          token === TokenType.NULL
+        ) {
+          if (this.mode === TokenParserMode.OBJECT) {
+            (this.currentValue as JsonObject)[this.key as string] = value;
+            this.setStateIfComplete(OptimisticTokenParserState.COMMA, type);
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            (this.currentValue as JsonArray)[this.key as number] = value;
+            this.setStateIfComplete(OptimisticTokenParserState.COMMA, type);
+          }
+
+          this.checkIfEnded();
+          return;
+        }
+
+        if (token === TokenType.LEFT_BRACE) {
+          this.push();
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setCurrentValue(
+              ((this.currentValue as JsonObject)[this.key as string] = {}),
+            );
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            const val = {};
+            (this.currentValue as JsonArray)[this.key as number] = val;
+            this.setCurrentValue(val);
+          } else {
+            this.setCurrentValue({});
+          }
+          this.mode = TokenParserMode.OBJECT;
+          this.setStateIfComplete(OptimisticTokenParserState.KEY, type);
+          this.key = undefined;
+          return;
+        }
+
+        if (token === TokenType.LEFT_BRACKET) {
+          this.push();
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setCurrentValue(
+              ((this.currentValue as JsonObject)[this.key as string] = []),
+            );
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            const val: JsonArray = [];
+            (this.currentValue as JsonArray)[this.key as number] = val;
+            this.setCurrentValue(val);
+          } else {
+            this.setCurrentValue([]);
+          }
+          this.mode = TokenParserMode.ARRAY;
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          this.key = 0;
+          return;
+        }
+
+        if (
+          this.mode === TokenParserMode.ARRAY &&
+          token === TokenType.RIGHT_BRACKET &&
+          (this.currentValue as JsonArray).length === 0
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.KEY) {
+        if (token === TokenType.STRING) {
+          this.key = value as string;
+          (this.currentValue as JsonObject)[this.key] = undefined;
+          this.setStateIfComplete(OptimisticTokenParserState.COLON, type);
+          return;
+        }
+
+        if (
+          token === TokenType.RIGHT_BRACE &&
+          Object.keys(this.currentValue as JsonObject).length === 0
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.COLON) {
+        if (token === TokenType.COLON) {
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.COMMA) {
+        if (token === TokenType.COMMA) {
+          if (this.mode === TokenParserMode.ARRAY) {
+            this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+            (this.key as number) += 1;
+            return;
+          }
+
+          /* istanbul ignore else */
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setStateIfComplete(OptimisticTokenParserState.KEY, type);
+            return;
+          }
+        }
+
+        if (
+          (token === TokenType.RIGHT_BRACE &&
+            this.mode === TokenParserMode.OBJECT) ||
+          (token === TokenType.RIGHT_BRACKET &&
+            this.mode === TokenParserMode.ARRAY)
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.SEPARATOR) {
+        if (token === TokenType.SEPARATOR && value === this.separator) {
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          return;
+        }
+      }
+
+      throw new OptimisticTokenParserError(
+        `Unexpected ${TokenType[token]} (${JSON.stringify(
+          value,
+        )}) in state ${TokenParserStateToString(this.state)}`,
+      );
+    } catch (err: any) {
+      this.error(err);
+    }
+  }
+
+  public error(err: Error): void {
+    if (this.state !== OptimisticTokenParserState.ENDED) {
+      this.state = OptimisticTokenParserState.ERROR;
+    }
+
+    this.onError(err);
+  }
+
+  public end(): void {
+    if (
+      (this.state !== OptimisticTokenParserState.VALUE &&
+        this.state !== OptimisticTokenParserState.SEPARATOR) ||
+      this.stack.length > 0
+    ) {
+      this.error(
+        new Error(
+          `Parser ended in mid-parsing (state: ${TokenParserStateToString(
+            this.state,
+          )}). Either not all the data was received or the data was invalid.`,
+        ),
+      );
+    } else {
+      this.state = OptimisticTokenParserState.ENDED;
+      this.onEnd();
+    }
+  }
+
+  public onError(err: Error): void {
+    // Override me
+    throw err;
+  }
+
+  public onEnd(): void {
+    // Override me
+  }
+}

--- a/packages/plainjs/dist/deno/optimistic/types.ts
+++ b/packages/plainjs/dist/deno/optimistic/types.ts
@@ -1,0 +1,9 @@
+import type { JsonPrimitive } from "../utils/types/jsonTypes.ts";
+import type TokenType from "../utils/types/tokenType.ts";
+
+export interface OptimisticParsedTokenInfo {
+  token: TokenType;
+  value: JsonPrimitive;
+  offset: number;
+  type: "complete" | "incomplete";
+}

--- a/packages/plainjs/dist/deno/utils/types/jsonTypes.ts
+++ b/packages/plainjs/dist/deno/utils/types/jsonTypes.ts
@@ -1,5 +1,7 @@
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonKey = string | number | undefined;
-export type JsonObject = { [key: string]: JsonPrimitive | JsonStruct };
+export type JsonObject = {
+  [key: string]: JsonPrimitive | JsonStruct | undefined;
+};
 export type JsonArray = (JsonPrimitive | JsonStruct)[];
 export type JsonStruct = JsonObject | JsonArray;

--- a/packages/plainjs/src/optimistic/index.ts
+++ b/packages/plainjs/src/optimistic/index.ts
@@ -1,0 +1,4 @@
+export * from "./jsonparser.js";
+export * from "./tokenizer.js";
+export * from "./tokenparser.js";
+export * from "./types.js";

--- a/packages/plainjs/src/optimistic/jsonparser.ts
+++ b/packages/plainjs/src/optimistic/jsonparser.ts
@@ -1,0 +1,64 @@
+import type { TokenizerOptions } from "../tokenizer.js";
+import type { TokenParserOptions } from "../tokenparser.js";
+import type { JsonStruct } from "../utils/types/jsonTypes.js";
+import type { ParsedTokenInfo } from "../utils/types/parsedTokenInfo.js";
+import { OptimisticTokenizer } from "./tokenizer.js";
+import { OptimisticTokenParser } from "./tokenparser.js";
+
+export interface OptimisticJSONParserOptions
+  extends TokenizerOptions,
+    TokenParserOptions {}
+
+export class OptimisticJSONParser {
+  private tokenizer: OptimisticTokenizer;
+  private tokenParser: OptimisticTokenParser;
+
+  constructor(opts: OptimisticJSONParserOptions = {}) {
+    this.tokenizer = new OptimisticTokenizer(opts);
+    this.tokenParser = new OptimisticTokenParser(opts);
+
+    this.tokenizer.onToken = this.tokenParser.write.bind(this.tokenParser);
+    this.tokenizer.onEnd = () => {
+      if (!this.tokenParser.isEnded) this.tokenParser.end();
+    };
+
+    this.tokenParser.onError = this.tokenizer.error.bind(this.tokenizer);
+    this.tokenParser.onEnd = () => {
+      if (!this.tokenizer.isEnded) this.tokenizer.end();
+    };
+  }
+
+  public get isEnded(): boolean {
+    return this.tokenizer.isEnded && this.tokenParser.isEnded;
+  }
+
+  public write(input: Iterable<number> | string): void {
+    this.tokenizer.write(input);
+  }
+
+  public end(): void {
+    this.tokenizer.end();
+  }
+
+  public set onToken(cb: (parsedTokenInfo: ParsedTokenInfo) => void) {
+    this.tokenizer.onToken = (parsedToken) => {
+      cb(parsedToken);
+      this.tokenParser.write(parsedToken);
+    };
+  }
+
+  public get value(): JsonStruct | undefined {
+    return this.tokenParser.value;
+  }
+
+  public set onError(cb: (err: Error) => void) {
+    this.tokenizer.onError = cb;
+  }
+
+  public set onEnd(cb: () => void) {
+    this.tokenParser.onEnd = () => {
+      if (!this.tokenizer.isEnded) this.tokenizer.end();
+      cb.call(this.tokenParser);
+    };
+  }
+}

--- a/packages/plainjs/src/optimistic/tokenizer.ts
+++ b/packages/plainjs/src/optimistic/tokenizer.ts
@@ -1,0 +1,790 @@
+import {
+  BufferedString,
+  NonBufferedString,
+  type StringBuilder,
+} from "../utils/bufferedString.js";
+import TokenType from "../utils/types/tokenType.js";
+import { charset, escapedSequences } from "../utils/utf-8.js";
+import type { OptimisticParsedTokenInfo } from "./types.js";
+
+// Tokenizer States
+const enum OptimisticTokenizerStates {
+  START,
+  ENDED,
+  ERROR,
+  TRUE1,
+  TRUE2,
+  TRUE3,
+  FALSE1,
+  FALSE2,
+  FALSE3,
+  FALSE4,
+  NULL1,
+  NULL2,
+  NULL3,
+  STRING_DEFAULT,
+  STRING_AFTER_BACKSLASH,
+  STRING_UNICODE_DIGIT_1,
+  STRING_UNICODE_DIGIT_2,
+  STRING_UNICODE_DIGIT_3,
+  STRING_UNICODE_DIGIT_4,
+  STRING_INCOMPLETE_CHAR,
+  NUMBER_AFTER_INITIAL_MINUS,
+  NUMBER_AFTER_INITIAL_ZERO,
+  NUMBER_AFTER_INITIAL_NON_ZERO,
+  NUMBER_AFTER_FULL_STOP,
+  NUMBER_AFTER_DECIMAL,
+  NUMBER_AFTER_E,
+  NUMBER_AFTER_E_AND_SIGN,
+  NUMBER_AFTER_E_AND_DIGIT,
+  SEPARATOR,
+}
+
+function OptimisticTokenizerStateToString(
+  tokenizerState: OptimisticTokenizerStates,
+): string {
+  return [
+    "START",
+    "ENDED",
+    "ERROR",
+    "TRUE1",
+    "TRUE2",
+    "TRUE3",
+    "FALSE1",
+    "FALSE2",
+    "FALSE3",
+    "FALSE4",
+    "NULL1",
+    "NULL2",
+    "NULL3",
+    "STRING_DEFAULT",
+    "STRING_AFTER_BACKSLASH",
+    "STRING_UNICODE_DIGIT_1",
+    "STRING_UNICODE_DIGIT_2",
+    "STRING_UNICODE_DIGIT_3",
+    "STRING_UNICODE_DIGIT_4",
+    "STRING_INCOMPLETE_CHAR",
+    "NUMBER_AFTER_INITIAL_MINUS",
+    "NUMBER_AFTER_INITIAL_ZERO",
+    "NUMBER_AFTER_INITIAL_NON_ZERO",
+    "NUMBER_AFTER_FULL_STOP",
+    "NUMBER_AFTER_DECIMAL",
+    "NUMBER_AFTER_E",
+    "NUMBER_AFTER_E_AND_SIGN",
+    "NUMBER_AFTER_E_AND_DIGIT",
+    "SEPARATOR",
+  ][tokenizerState];
+}
+
+export interface OptimisticTokenizerOptions {
+  stringBufferSize?: number;
+  numberBufferSize?: number;
+  separator?: string;
+}
+
+const defaultOpts: OptimisticTokenizerOptions = {
+  stringBufferSize: 0,
+  numberBufferSize: 0,
+  separator: undefined,
+};
+
+export class OptimisticTokenizerError extends Error {
+  constructor(message: string) {
+    super(message);
+    // Typescript is broken. This is a workaround
+    Object.setPrototypeOf(this, OptimisticTokenizerError.prototype);
+  }
+}
+
+export class OptimisticTokenizer {
+  private state = OptimisticTokenizerStates.START;
+
+  private separator?: string;
+  private separatorBytes?: Uint8Array;
+  private separatorIndex = 0;
+  private bufferedString: StringBuilder;
+  private bufferedNumber: StringBuilder;
+
+  private unicode?: string; // unicode escapes
+  private highSurrogate?: number;
+  private bytes_remaining = 0; // number of bytes remaining in multi byte utf8 char to read after split boundary
+  private bytes_in_sequence = 0; // bytes in multi byte utf8 char to read
+  private char_split_buffer = new Uint8Array(4); // for rebuilding chars split before boundary is reached
+  private encoder = new TextEncoder();
+  private offset = -1;
+
+  constructor(opts?: OptimisticTokenizerOptions) {
+    opts = { ...defaultOpts, ...opts };
+
+    this.bufferedString =
+      opts.stringBufferSize && opts.stringBufferSize > 4
+        ? new BufferedString(opts.stringBufferSize)
+        : new NonBufferedString();
+    this.bufferedNumber =
+      opts.numberBufferSize && opts.numberBufferSize > 0
+        ? new BufferedString(opts.numberBufferSize)
+        : new NonBufferedString();
+
+    this.separator = opts.separator;
+    this.separatorBytes = opts.separator
+      ? this.encoder.encode(opts.separator)
+      : undefined;
+  }
+
+  public get isEnded(): boolean {
+    return this.state === OptimisticTokenizerStates.ENDED;
+  }
+
+  public write(input: Iterable<number> | string): void {
+    try {
+      let buffer: Uint8Array;
+      if (input instanceof Uint8Array) {
+        buffer = input;
+      } else if (typeof input === "string") {
+        buffer = this.encoder.encode(input);
+      } else if (
+        (typeof input === "object" && "buffer" in input) ||
+        Array.isArray(input)
+      ) {
+        buffer = Uint8Array.from(input);
+      } else {
+        throw new TypeError(
+          "Unexpected type. The `write` function only accepts Arrays, TypedArrays and Strings.",
+        );
+      }
+
+      for (let i = 0; i < buffer.length; i += 1) {
+        const n = buffer[i];
+
+        switch (this.state) {
+          case OptimisticTokenizerStates.START:
+            this.offset += 1;
+
+            if (this.separatorBytes && n === this.separatorBytes[0]) {
+              if (this.separatorBytes.length === 1) {
+                this.state = OptimisticTokenizerStates.START;
+                this.onToken({
+                  token: TokenType.SEPARATOR,
+                  value: this.separator as string,
+                  offset: this.offset + this.separatorBytes.length - 1,
+                  type: "complete",
+                });
+                continue;
+              }
+              this.state = OptimisticTokenizerStates.SEPARATOR;
+              continue;
+            }
+
+            if (
+              n === charset.SPACE ||
+              n === charset.NEWLINE ||
+              n === charset.CARRIAGE_RETURN ||
+              n === charset.TAB
+            ) {
+              // whitespace
+              continue;
+            }
+
+            if (n === charset.LEFT_CURLY_BRACKET) {
+              this.onToken({
+                token: TokenType.LEFT_BRACE,
+                value: "{",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.RIGHT_CURLY_BRACKET) {
+              this.onToken({
+                token: TokenType.RIGHT_BRACE,
+                value: "}",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.LEFT_SQUARE_BRACKET) {
+              this.onToken({
+                token: TokenType.LEFT_BRACKET,
+                value: "[",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.RIGHT_SQUARE_BRACKET) {
+              this.onToken({
+                token: TokenType.RIGHT_BRACKET,
+                value: "]",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.COLON) {
+              this.onToken({
+                token: TokenType.COLON,
+                value: ":",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+            if (n === charset.COMMA) {
+              this.onToken({
+                token: TokenType.COMMA,
+                value: ",",
+                offset: this.offset,
+                type: "complete",
+              });
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_T) {
+              this.state = OptimisticTokenizerStates.TRUE1;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_F) {
+              this.state = OptimisticTokenizerStates.FALSE1;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_N) {
+              this.state = OptimisticTokenizerStates.NULL1;
+              continue;
+            }
+
+            if (n === charset.QUOTATION_MARK) {
+              this.bufferedString.reset();
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+
+            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state =
+                OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO;
+              continue;
+            }
+
+            if (n === charset.DIGIT_ZERO) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO;
+              continue;
+            }
+
+            if (n === charset.HYPHEN_MINUS) {
+              this.bufferedNumber.reset();
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_MINUS;
+              continue;
+            }
+
+            break;
+          // STRING
+          case OptimisticTokenizerStates.STRING_DEFAULT:
+            if (n === charset.QUOTATION_MARK) {
+              const string = this.bufferedString.toString();
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.STRING,
+                value: string,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += this.bufferedString.byteLength + 1;
+              continue;
+            }
+
+            if (n === charset.REVERSE_SOLIDUS) {
+              this.state = OptimisticTokenizerStates.STRING_AFTER_BACKSLASH;
+              continue;
+            }
+
+            if (n >= 128) {
+              // Parse multi byte (>=128) chars one at a time
+              if (n >= 194 && n <= 223) {
+                this.bytes_in_sequence = 2;
+              } else if (n <= 239) {
+                this.bytes_in_sequence = 3;
+              } else {
+                this.bytes_in_sequence = 4;
+              }
+
+              if (this.bytes_in_sequence <= buffer.length - i) {
+                // if bytes needed to complete char fall outside buffer length, we have a boundary split
+                this.bufferedString.appendBuf(
+                  buffer,
+                  i,
+                  i + this.bytes_in_sequence,
+                );
+                i += this.bytes_in_sequence - 1;
+                continue;
+              }
+
+              this.bytes_remaining = i + this.bytes_in_sequence - buffer.length;
+              this.char_split_buffer.set(buffer.subarray(i));
+              i = buffer.length - 1;
+              this.state = OptimisticTokenizerStates.STRING_INCOMPLETE_CHAR;
+              continue;
+            }
+
+            if (n >= charset.SPACE) {
+              this.bufferedString.appendChar(n);
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.STRING_INCOMPLETE_CHAR:
+            // check for carry over of a multi byte char split between data chunks
+            // & fill temp buffer it with start of this data chunk up to the boundary limit set in the last iteration
+            this.char_split_buffer.set(
+              buffer.subarray(i, i + this.bytes_remaining),
+              this.bytes_in_sequence - this.bytes_remaining,
+            );
+            this.bufferedString.appendBuf(
+              this.char_split_buffer,
+              0,
+              this.bytes_in_sequence,
+            );
+            i = this.bytes_remaining - 1;
+            this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+            continue;
+          case OptimisticTokenizerStates.STRING_AFTER_BACKSLASH: {
+            const controlChar = escapedSequences[n];
+            if (controlChar) {
+              this.bufferedString.appendChar(controlChar);
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.unicode = "";
+              this.state = OptimisticTokenizerStates.STRING_UNICODE_DIGIT_1;
+              continue;
+            }
+
+            break;
+          }
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_1:
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_2:
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_3:
+            if (
+              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+              (n >= charset.LATIN_CAPITAL_LETTER_A &&
+                n <= charset.LATIN_CAPITAL_LETTER_F) ||
+              (n >= charset.LATIN_SMALL_LETTER_A &&
+                n <= charset.LATIN_SMALL_LETTER_F)
+            ) {
+              this.unicode += String.fromCharCode(n);
+              this.state += 1;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.STRING_UNICODE_DIGIT_4:
+            if (
+              (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) ||
+              (n >= charset.LATIN_CAPITAL_LETTER_A &&
+                n <= charset.LATIN_CAPITAL_LETTER_F) ||
+              (n >= charset.LATIN_SMALL_LETTER_A &&
+                n <= charset.LATIN_SMALL_LETTER_F)
+            ) {
+              const intVal = parseInt(
+                this.unicode + String.fromCharCode(n),
+                16,
+              );
+              if (this.highSurrogate === undefined) {
+                if (intVal >= 0xd800 && intVal <= 0xdbff) {
+                  // <55296,56319> - highSurrogate
+                  this.highSurrogate = intVal;
+                } else {
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(String.fromCharCode(intVal)),
+                  );
+                }
+              } else {
+                if (intVal >= 0xdc00 && intVal <= 0xdfff) {
+                  // <56320,57343> - lowSurrogate
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(
+                      String.fromCharCode(this.highSurrogate, intVal),
+                    ),
+                  );
+                } else {
+                  this.bufferedString.appendBuf(
+                    this.encoder.encode(
+                      String.fromCharCode(this.highSurrogate),
+                    ),
+                  );
+                }
+                this.highSurrogate = undefined;
+              }
+              this.state = OptimisticTokenizerStates.STRING_DEFAULT;
+              continue;
+            }
+            break;
+          // Number
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_MINUS:
+            if (n === charset.DIGIT_ZERO) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO;
+              continue;
+            }
+
+            if (n >= charset.DIGIT_ONE && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state =
+                OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+            if (n === charset.FULL_STOP) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP;
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            if (n === charset.FULL_STOP) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP;
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          case OptimisticTokenizerStates.NUMBER_AFTER_FULL_STOP:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            if (
+              n === charset.LATIN_SMALL_LETTER_E ||
+              n === charset.LATIN_CAPITAL_LETTER_E
+            ) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E;
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+
+          // @ts-ignore fallthrough
+          case OptimisticTokenizerStates.NUMBER_AFTER_E:
+            if (n === charset.PLUS_SIGN || n === charset.HYPHEN_MINUS) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E_AND_SIGN;
+              continue;
+            }
+          case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_SIGN:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              this.state = OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT;
+              continue;
+            }
+
+            break;
+          case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+            if (n >= charset.DIGIT_ZERO && n <= charset.DIGIT_NINE) {
+              this.bufferedNumber.appendChar(n);
+              continue;
+            }
+
+            i -= 1;
+            this.state = OptimisticTokenizerStates.START;
+            this.emitNumber();
+            continue;
+          // TRUE
+          case OptimisticTokenizerStates.TRUE1:
+            if (n === charset.LATIN_SMALL_LETTER_R) {
+              this.state = OptimisticTokenizerStates.TRUE2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.TRUE2:
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.state = OptimisticTokenizerStates.TRUE3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.TRUE3:
+            if (n === charset.LATIN_SMALL_LETTER_E) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.TRUE,
+                value: true,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 3;
+              continue;
+            }
+            break;
+          // FALSE
+          case OptimisticTokenizerStates.FALSE1:
+            if (n === charset.LATIN_SMALL_LETTER_A) {
+              this.state = OptimisticTokenizerStates.FALSE2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE2:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.FALSE3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE3:
+            if (n === charset.LATIN_SMALL_LETTER_S) {
+              this.state = OptimisticTokenizerStates.FALSE4;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.FALSE4:
+            if (n === charset.LATIN_SMALL_LETTER_E) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.FALSE,
+                value: false,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 4;
+              continue;
+            }
+            break;
+          // NULL
+          case OptimisticTokenizerStates.NULL1:
+            if (n === charset.LATIN_SMALL_LETTER_U) {
+              this.state = OptimisticTokenizerStates.NULL2;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.NULL2:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.NULL3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.NULL3:
+            if (n === charset.LATIN_SMALL_LETTER_L) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.NULL,
+                value: null,
+                offset: this.offset,
+                type: "complete",
+              });
+              this.offset += 3;
+              continue;
+            }
+            break;
+          case OptimisticTokenizerStates.SEPARATOR:
+            this.separatorIndex += 1;
+            if (
+              !this.separatorBytes ||
+              n !== this.separatorBytes[this.separatorIndex]
+            ) {
+              break;
+            }
+            if (this.separatorIndex === this.separatorBytes.length - 1) {
+              this.state = OptimisticTokenizerStates.START;
+              this.onToken({
+                token: TokenType.SEPARATOR,
+                value: this.separator as string,
+                offset: this.offset + this.separatorIndex,
+                type: "complete",
+              });
+              this.separatorIndex = 0;
+            }
+            continue;
+          case OptimisticTokenizerStates.ENDED:
+            if (
+              n === charset.SPACE ||
+              n === charset.NEWLINE ||
+              n === charset.CARRIAGE_RETURN ||
+              n === charset.TAB
+            ) {
+              // whitespace
+              continue;
+            }
+        }
+
+        throw new OptimisticTokenizerError(
+          `Unexpected "${String.fromCharCode(
+            n,
+          )}" at position "${i}" in state ${OptimisticTokenizerStateToString(
+            this.state,
+          )}`,
+        );
+      }
+
+      switch (this.state) {
+        case OptimisticTokenizerStates.TRUE1:
+        case OptimisticTokenizerStates.TRUE2:
+        case OptimisticTokenizerStates.TRUE3:
+          this.onToken({
+            token: TokenType.TRUE,
+            value: true,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.FALSE1:
+        case OptimisticTokenizerStates.FALSE2:
+        case OptimisticTokenizerStates.FALSE3:
+        case OptimisticTokenizerStates.FALSE4:
+          this.onToken({
+            token: TokenType.FALSE,
+            value: false,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.NULL1:
+        case OptimisticTokenizerStates.NULL2:
+        case OptimisticTokenizerStates.NULL3:
+          this.onToken({
+            token: TokenType.NULL,
+            value: null,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        case OptimisticTokenizerStates.STRING_DEFAULT: {
+          const string = this.bufferedString.toString();
+          this.onToken({
+            token: TokenType.STRING,
+            value: string,
+            offset: this.offset,
+            type: "incomplete",
+          });
+          break;
+        }
+        case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+        case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+        case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+        case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+          this.onToken({
+            token: TokenType.NUMBER,
+            value: this.parseNumber(this.bufferedNumber.toString()),
+            offset: this.offset,
+            type: "incomplete",
+          });
+      }
+    } catch (err: any) {
+      this.error(err);
+    }
+  }
+
+  private emitNumber(): void {
+    this.onToken({
+      token: TokenType.NUMBER,
+      value: this.parseNumber(this.bufferedNumber.toString()),
+      offset: this.offset,
+      type: "complete",
+    });
+    this.offset += this.bufferedNumber.byteLength - 1;
+  }
+
+  protected parseNumber(numberStr: string): number {
+    return Number(numberStr);
+  }
+
+  public error(err: Error): void {
+    if (this.state !== OptimisticTokenizerStates.ENDED) {
+      this.state = OptimisticTokenizerStates.ERROR;
+    }
+
+    this.onError(err);
+  }
+
+  public end(): void {
+    switch (this.state) {
+      case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_ZERO:
+      case OptimisticTokenizerStates.NUMBER_AFTER_INITIAL_NON_ZERO:
+      case OptimisticTokenizerStates.NUMBER_AFTER_DECIMAL:
+      case OptimisticTokenizerStates.NUMBER_AFTER_E_AND_DIGIT:
+        this.state = OptimisticTokenizerStates.ENDED;
+        this.emitNumber();
+        this.onEnd();
+        break;
+      case OptimisticTokenizerStates.START:
+      case OptimisticTokenizerStates.ERROR:
+      case OptimisticTokenizerStates.SEPARATOR:
+        this.state = OptimisticTokenizerStates.ENDED;
+        this.onEnd();
+        break;
+      default:
+        this.error(
+          new OptimisticTokenizerError(
+            `Tokenizer ended in the middle of a token (state: ${OptimisticTokenizerStateToString(
+              this.state,
+            )}). Either not all the data was received or the data was invalid.`,
+          ),
+        );
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public onToken(parsedToken: OptimisticParsedTokenInfo): void {
+    // Override me
+    throw new OptimisticTokenizerError(
+      'Can\'t emit tokens before the "onToken" callback has been set up.',
+    );
+  }
+
+  public onError(err: Error): void {
+    // Override me
+    throw err;
+  }
+
+  public onEnd(): void {
+    // Override me
+  }
+}

--- a/packages/plainjs/src/optimistic/tokenparser.ts
+++ b/packages/plainjs/src/optimistic/tokenparser.ts
@@ -1,0 +1,296 @@
+import type {
+  JsonArray,
+  JsonKey,
+  JsonObject,
+  JsonStruct,
+} from "../utils/types/jsonTypes.js";
+import { TokenParserMode } from "../utils/types/stackElement.js";
+import TokenType from "../utils/types/tokenType.js";
+import type { OptimisticParsedTokenInfo } from "./types.js";
+
+// Parser States
+const enum OptimisticTokenParserState {
+  VALUE,
+  KEY,
+  COLON,
+  COMMA,
+  ENDED,
+  ERROR,
+  SEPARATOR,
+}
+
+function TokenParserStateToString(state: OptimisticTokenParserState): string {
+  return ["VALUE", "KEY", "COLON", "COMMA", "ENDED", "ERROR", "SEPARATOR"][
+    state
+  ];
+}
+
+export interface OptimisticTokenParserOptions {
+  separator?: string;
+}
+
+export interface OptimisticStackElement {
+  key: JsonKey;
+  value: JsonStruct;
+  mode?: TokenParserMode;
+}
+
+const defaultOpts: OptimisticTokenParserOptions = {
+  separator: undefined,
+};
+
+export class OptimisticTokenParserError extends Error {
+  constructor(message: string) {
+    super(message);
+    // Typescript is broken. This is a workaround
+    Object.setPrototypeOf(this, OptimisticTokenParserError.prototype);
+  }
+}
+
+export class OptimisticTokenParser {
+  private readonly separator?: string;
+  private state: OptimisticTokenParserState = OptimisticTokenParserState.VALUE;
+  private mode: TokenParserMode | undefined = undefined;
+  private key: JsonKey = undefined;
+  private currentValue: JsonStruct | undefined = undefined;
+  public value: JsonStruct | undefined = undefined;
+  private stack: OptimisticStackElement[] = [];
+
+  constructor(opts?: OptimisticTokenParserOptions) {
+    opts = { ...defaultOpts, ...opts };
+
+    this.separator = opts.separator;
+  }
+
+  private push(): void {
+    this.stack.push({
+      key: this.key,
+      value: this.currentValue as JsonStruct,
+      mode: this.mode,
+    });
+  }
+
+  private pop(): void {
+    ({
+      key: this.key,
+      value: this.currentValue,
+      mode: this.mode,
+    } = this.stack.pop() as OptimisticStackElement);
+
+    this.state =
+      this.mode !== undefined
+        ? OptimisticTokenParserState.COMMA
+        : OptimisticTokenParserState.VALUE;
+
+    this.checkIfEnded();
+  }
+
+  private checkIfEnded(): void {
+    if (this.stack.length === 0) {
+      if (this.separator) {
+        this.state = OptimisticTokenParserState.SEPARATOR;
+      } else if (this.separator === undefined) {
+        this.end();
+      }
+      // else if separator === '', expect next JSON object.
+    }
+  }
+
+  public get isEnded(): boolean {
+    return this.state === OptimisticTokenParserState.ENDED;
+  }
+
+  private setStateIfComplete(
+    state: OptimisticTokenParserState,
+    type: "complete" | "incomplete",
+  ): void {
+    if (type === "complete") {
+      this.state = state;
+    }
+  }
+
+  private setCurrentValue(value: JsonStruct): void {
+    if (this.value === undefined) {
+      this.value = value;
+    }
+
+    this.currentValue = value;
+  }
+
+  public write({
+    token,
+    value,
+    type,
+  }: Omit<OptimisticParsedTokenInfo, "offset">): void {
+    try {
+      if (this.state === OptimisticTokenParserState.VALUE) {
+        if (
+          token === TokenType.STRING ||
+          token === TokenType.NUMBER ||
+          token === TokenType.TRUE ||
+          token === TokenType.FALSE ||
+          token === TokenType.NULL
+        ) {
+          if (this.mode === TokenParserMode.OBJECT) {
+            (this.currentValue as JsonObject)[this.key as string] = value;
+            this.setStateIfComplete(OptimisticTokenParserState.COMMA, type);
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            (this.currentValue as JsonArray)[this.key as number] = value;
+            this.setStateIfComplete(OptimisticTokenParserState.COMMA, type);
+          }
+
+          this.checkIfEnded();
+          return;
+        }
+
+        if (token === TokenType.LEFT_BRACE) {
+          this.push();
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setCurrentValue(
+              ((this.currentValue as JsonObject)[this.key as string] = {}),
+            );
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            const val = {};
+            (this.currentValue as JsonArray)[this.key as number] = val;
+            this.setCurrentValue(val);
+          } else {
+            this.setCurrentValue({});
+          }
+          this.mode = TokenParserMode.OBJECT;
+          this.setStateIfComplete(OptimisticTokenParserState.KEY, type);
+          this.key = undefined;
+          return;
+        }
+
+        if (token === TokenType.LEFT_BRACKET) {
+          this.push();
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setCurrentValue(
+              ((this.currentValue as JsonObject)[this.key as string] = []),
+            );
+          } else if (this.mode === TokenParserMode.ARRAY) {
+            const val: JsonArray = [];
+            (this.currentValue as JsonArray)[this.key as number] = val;
+            this.setCurrentValue(val);
+          } else {
+            this.setCurrentValue([]);
+          }
+          this.mode = TokenParserMode.ARRAY;
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          this.key = 0;
+          return;
+        }
+
+        if (
+          this.mode === TokenParserMode.ARRAY &&
+          token === TokenType.RIGHT_BRACKET &&
+          (this.currentValue as JsonArray).length === 0
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.KEY) {
+        if (token === TokenType.STRING) {
+          this.key = value as string;
+          (this.currentValue as JsonObject)[this.key] = undefined;
+          this.setStateIfComplete(OptimisticTokenParserState.COLON, type);
+          return;
+        }
+
+        if (
+          token === TokenType.RIGHT_BRACE &&
+          Object.keys(this.currentValue as JsonObject).length === 0
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.COLON) {
+        if (token === TokenType.COLON) {
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.COMMA) {
+        if (token === TokenType.COMMA) {
+          if (this.mode === TokenParserMode.ARRAY) {
+            this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+            (this.key as number) += 1;
+            return;
+          }
+
+          /* istanbul ignore else */
+          if (this.mode === TokenParserMode.OBJECT) {
+            this.setStateIfComplete(OptimisticTokenParserState.KEY, type);
+            return;
+          }
+        }
+
+        if (
+          (token === TokenType.RIGHT_BRACE &&
+            this.mode === TokenParserMode.OBJECT) ||
+          (token === TokenType.RIGHT_BRACKET &&
+            this.mode === TokenParserMode.ARRAY)
+        ) {
+          this.pop();
+          return;
+        }
+      }
+
+      if (this.state === OptimisticTokenParserState.SEPARATOR) {
+        if (token === TokenType.SEPARATOR && value === this.separator) {
+          this.setStateIfComplete(OptimisticTokenParserState.VALUE, type);
+          return;
+        }
+      }
+
+      throw new OptimisticTokenParserError(
+        `Unexpected ${TokenType[token]} (${JSON.stringify(
+          value,
+        )}) in state ${TokenParserStateToString(this.state)}`,
+      );
+    } catch (err: any) {
+      this.error(err);
+    }
+  }
+
+  public error(err: Error): void {
+    if (this.state !== OptimisticTokenParserState.ENDED) {
+      this.state = OptimisticTokenParserState.ERROR;
+    }
+
+    this.onError(err);
+  }
+
+  public end(): void {
+    if (
+      (this.state !== OptimisticTokenParserState.VALUE &&
+        this.state !== OptimisticTokenParserState.SEPARATOR) ||
+      this.stack.length > 0
+    ) {
+      this.error(
+        new Error(
+          `Parser ended in mid-parsing (state: ${TokenParserStateToString(
+            this.state,
+          )}). Either not all the data was received or the data was invalid.`,
+        ),
+      );
+    } else {
+      this.state = OptimisticTokenParserState.ENDED;
+      this.onEnd();
+    }
+  }
+
+  public onError(err: Error): void {
+    // Override me
+    throw err;
+  }
+
+  public onEnd(): void {
+    // Override me
+  }
+}

--- a/packages/plainjs/src/optimistic/types.ts
+++ b/packages/plainjs/src/optimistic/types.ts
@@ -1,0 +1,9 @@
+import type { JsonPrimitive } from "../utils/types/jsonTypes.js";
+import type TokenType from "../utils/types/tokenType.js";
+
+export interface OptimisticParsedTokenInfo {
+  token: TokenType;
+  value: JsonPrimitive;
+  offset: number;
+  type: "complete" | "incomplete";
+}

--- a/packages/plainjs/src/utils/types/jsonTypes.ts
+++ b/packages/plainjs/src/utils/types/jsonTypes.ts
@@ -1,5 +1,7 @@
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonKey = string | number | undefined;
-export type JsonObject = { [key: string]: JsonPrimitive | JsonStruct };
+export type JsonObject = {
+  [key: string]: JsonPrimitive | JsonStruct | undefined;
+};
 export type JsonArray = (JsonPrimitive | JsonStruct)[];
 export type JsonStruct = JsonObject | JsonArray;

--- a/packages/plainjs/test/optimistic.ts
+++ b/packages/plainjs/test/optimistic.ts
@@ -1,0 +1,582 @@
+import { OptimisticJSONParser } from "../src/optimistic/jsonparser.js";
+import { OptimisticTokenizer } from "../src/optimistic/tokenizer.js";
+import TokenType from "../src/utils/types/tokenType.js";
+
+interface TokenizerTestData {
+  value: string;
+  expected: unknown[];
+}
+
+describe("optimistic tokenizing", () => {
+  const testData: TokenizerTestData[][] = [
+    [
+      {
+        value: "tr",
+        expected: [{ type: "incomplete", token: TokenType.TRUE, value: true }],
+      },
+    ],
+    [
+      {
+        value: "t",
+        expected: [{ type: "incomplete", token: TokenType.TRUE, value: true }],
+      },
+      {
+        value: "ru",
+        expected: [{ type: "incomplete", token: TokenType.TRUE, value: true }],
+      },
+    ],
+    [
+      {
+        value: "fal",
+        expected: [
+          { type: "incomplete", token: TokenType.FALSE, value: false },
+        ],
+      },
+    ],
+    [
+      {
+        value: "n",
+        expected: [{ type: "incomplete", token: TokenType.NULL, value: null }],
+      },
+    ],
+    [
+      {
+        value: "n",
+        expected: [{ type: "incomplete", token: TokenType.NULL, value: null }],
+      },
+      {
+        value: "u",
+        expected: [{ type: "incomplete", token: TokenType.NULL, value: null }],
+      },
+      {
+        value: "l",
+        expected: [{ type: "incomplete", token: TokenType.NULL, value: null }],
+      },
+      {
+        value: "l",
+        expected: [{ type: "complete", token: TokenType.NULL, value: null }],
+      },
+    ],
+    [
+      {
+        value: "{",
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "fo',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "incomplete", token: TokenType.STRING, value: "fo" },
+        ],
+      },
+      {
+        value: "o",
+        expected: [
+          { type: "incomplete", token: TokenType.STRING, value: "foo" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo"',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+        ],
+      },
+      {
+        value: ': "',
+        expected: [
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "incomplete", token: TokenType.STRING, value: "" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "ba',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "incomplete", token: TokenType.STRING, value: "ba" },
+        ],
+      },
+      {
+        value: "r",
+        expected: [
+          { type: "incomplete", token: TokenType.STRING, value: "bar" },
+        ],
+      },
+      {
+        value: '"',
+        expected: [{ type: "complete", token: TokenType.STRING, value: "bar" }],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar"',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+        ],
+      },
+      {
+        value: "}",
+        expected: [
+          { type: "complete", token: TokenType.RIGHT_BRACE, value: "}" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar" }',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.RIGHT_BRACE, value: "}" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "ba',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "incomplete", token: TokenType.STRING, value: "ba" },
+        ],
+      },
+      {
+        value: "z",
+        expected: [
+          { type: "incomplete", token: TokenType.STRING, value: "baz" },
+        ],
+      },
+      {
+        value: '": [',
+        expected: [
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "incomplete", token: TokenType.NUMBER, value: 1 },
+        ],
+      },
+      {
+        value: "2",
+        expected: [{ type: "incomplete", token: TokenType.NUMBER, value: 12 }],
+      },
+      {
+        value: "3, ",
+        expected: [
+          { type: "complete", token: TokenType.NUMBER, value: 123 },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1]',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.NUMBER, value: 1 },
+          { type: "complete", token: TokenType.RIGHT_BRACKET, value: "]" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", ',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+        ],
+      },
+      {
+        value: ' "baz": [1,',
+        expected: [
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.NUMBER, value: 1 },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1,2',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.NUMBER, value: 1 },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "incomplete", token: TokenType.NUMBER, value: 2 },
+        ],
+      },
+      {
+        value: "3, 4",
+        expected: [
+          { type: "complete", token: TokenType.NUMBER, value: 23 },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "incomplete", token: TokenType.NUMBER, value: 4 },
+        ],
+      },
+      {
+        value: "5",
+        expected: [{ type: "incomplete", token: TokenType.NUMBER, value: 45 }],
+      },
+      {
+        value: "6]   }",
+        expected: [
+          { type: "complete", token: TokenType.NUMBER, value: 456 },
+          { type: "complete", token: TokenType.RIGHT_BRACKET, value: "]" },
+          { type: "complete", token: TokenType.RIGHT_BRACE, value: "}" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz"',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+        ],
+      },
+      {
+        value: ": [{",
+        expected: [
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [{ "a',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "incomplete", token: TokenType.STRING, value: "a" },
+        ],
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [{ "a": "b',
+        expected: [
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "foo" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.STRING, value: "bar" },
+          { type: "complete", token: TokenType.COMMA, value: "," },
+          { type: "complete", token: TokenType.STRING, value: "baz" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "complete", token: TokenType.LEFT_BRACKET, value: "[" },
+          { type: "complete", token: TokenType.LEFT_BRACE, value: "{" },
+          { type: "complete", token: TokenType.STRING, value: "a" },
+          { type: "complete", token: TokenType.COLON, value: ":" },
+          { type: "incomplete", token: TokenType.STRING, value: "b" },
+        ],
+      },
+    ],
+  ];
+
+  testData.forEach((chunks, i) => {
+    const name = `[${i}] ${chunks.map((c) => c.value).join("")} (${
+      chunks.length
+    } chunks)`;
+    const expected = chunks.map((c) => c.expected).flat();
+
+    test(name, async () => {
+      const tokenizer = new OptimisticTokenizer();
+
+      const tokens: unknown[] = [];
+      tokenizer.onToken = (t) =>
+        tokens.push({ type: t.type, token: t.token, value: t.value });
+
+      for (const chunk of chunks) {
+        tokenizer.write(chunk.value);
+      }
+
+      expect(tokens).toMatchObject(expected);
+    });
+  });
+});
+
+interface ParserTestData {
+  value: string;
+  expected: unknown;
+}
+
+describe("optimistic parsing", () => {
+  const testData: ParserTestData[][] = [
+    [
+      {
+        value: " ",
+        expected: undefined,
+      },
+      {
+        value: "   ",
+        expected: undefined,
+      },
+    ],
+    [
+      {
+        value: "{",
+        expected: {},
+      },
+    ],
+    [
+      {
+        value: '{ "fo',
+        expected: { fo: undefined },
+      },
+      {
+        value: "o",
+        expected: { foo: undefined },
+      },
+    ],
+    [
+      {
+        value: '{ "foo"',
+        expected: { foo: undefined },
+      },
+      {
+        value: ': "',
+        expected: { foo: "" },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "ba',
+        expected: { foo: "ba" },
+      },
+      {
+        value: "r",
+        expected: { foo: "bar" },
+      },
+      {
+        value: '"',
+        expected: { foo: "bar" },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar"',
+        expected: { foo: "bar" },
+      },
+      {
+        value: "}",
+        expected: { foo: "bar" },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar" }',
+        expected: { foo: "bar" },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "ba',
+        expected: { foo: "bar", ba: undefined },
+      },
+      {
+        value: "z",
+        expected: { foo: "bar", baz: undefined },
+      },
+      {
+        value: '": [',
+        expected: { foo: "bar", baz: [] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [',
+        expected: { foo: "bar", baz: [] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1',
+        expected: { foo: "bar", baz: [1] },
+      },
+      {
+        value: "2",
+        expected: { foo: "bar", baz: [12] },
+      },
+      {
+        value: "3, ",
+        expected: { foo: "bar", baz: [123] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1]',
+        expected: { foo: "bar", baz: [1] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", ',
+        expected: { foo: "bar" },
+      },
+      {
+        value: ' "baz": [1,',
+        expected: { foo: "bar", baz: [1] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [1,2',
+        expected: { foo: "bar", baz: [1, 2] },
+      },
+      {
+        value: "3, 4",
+        expected: { foo: "bar", baz: [1, 23, 4] },
+      },
+      {
+        value: "5",
+        expected: { foo: "bar", baz: [1, 23, 45] },
+      },
+      {
+        value: "6]   }",
+        expected: { foo: "bar", baz: [1, 23, 456] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz"',
+        expected: { foo: "bar", baz: undefined },
+      },
+      {
+        value: ": [{",
+        expected: { foo: "bar", baz: [{}] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [{ "a',
+        expected: { foo: "bar", baz: [{ a: undefined }] },
+      },
+    ],
+    [
+      {
+        value: '{ "foo": "bar", "baz": [{ "a": "b',
+        expected: { foo: "bar", baz: [{ a: "b" }] },
+      },
+    ],
+  ];
+
+  testData.forEach((chunks, i) => {
+    const name = `[${i}] ${chunks.map((c) => c.value).join("")} (${
+      chunks.length
+    } chunks)`;
+    const expected = chunks.map((c) => c.expected);
+
+    test(name, async () => {
+      const parser = new OptimisticJSONParser();
+
+      const values: unknown[] = [];
+      for (const chunk of chunks) {
+        parser.write(chunk.value);
+
+        if (parser.value) {
+          values.push(structuredClone(parser.value));
+        } else {
+          values.push(undefined);
+        }
+      }
+
+      expect(values).toMatchObject(expected);
+    });
+  });
+});
+
+function structuredClone(x: unknown): unknown {
+  if (x === undefined || x === null) {
+    return x;
+  }
+
+  if (Array.isArray(x)) {
+    return x.map(structuredClone);
+  }
+
+  if (typeof x === "object") {
+    return Object.fromEntries(
+      Object.entries(x).map(([k, v]) => [k, structuredClone(v)])
+    );
+  }
+
+  return x;
+}


### PR DESCRIPTION
# Problem

Incremental parsing is super useful in the face of streamed data. A growing use case for streamed data that needs to be parsed is that returned by AIs/chatbots such as OpenAI's GPT. The GPT message payload `{ "content": "Hi, how are you doing today?" }` might be sent as the following chunks (indented to try and improve readability):

```
{ "con
      ten
         t": "
              Hi, h
                   ow are
                          you doi
                                 ng to
                                      day?
                                          " }
```

If using a GPT function call, in which one can ask GPT to indicate when it would like to call some specified function with a set of arguments, GPT may respond with a (streamed) JSON payload that additionally contains stringified JSON. The payload `{ "name": "getWeather", "arguments": "{ \"city\": \"London\" }" }` might be chunked as follows:

```
{ "nam
      e" : "g
             etWeat
                   her", "ar
                            gume
                                nts": "{
                                         \"
                                           city\":
                                                   \"Lon
                                                        don\" }"
                                                                 }
```

As it stands, `@streamparser/json` allows one to feed a parser with chunks as they come, but it doesn't allow one access to any intermediate state. This is discussed a bit in #31 and the rationale makes sense -- such intermediate state could involve "guessing" what might come next, or making assumptions about whether or not a full parse will eventually succeed. #31 provides a workaround, but it does not work (as far as I can tell) for arbitrarily-nested JSON substructures. Ideally, it'd be possible at any point in the parsing process to have a view of the JSON that "might eventually be produced", e.g. for updating a front-end rendering of the respond in real time. For instance, in the case of a function call such as `{ "name": "offerSuggestions", "arguments": "[\"First\", \"Second\"]" }`, it would be useful to have a view that at various points (optimistically) provided the arrays `[]`, `["Fir"]`, `["First"]`, `["First", "Sec"]` and `["First", "Second"]` (for instance, depending on how the chunks fall).

# Proposal

This PR introduces "optimistic" variants of the existing tokenizer, token parser and combination JSON parser. The design is as follows:

* The optimistic tokenizer works just like a normal tokenizer, except that when it has finished emitting "complete" tokens in response to processing a provided piece of input (the argument to `write`), it may emit an additional "incomplete" token. Some examples:
```
write('{ "foo": "bar" }')
-> complete LEFT_BRACE, complete STRING[foo], complete COLON, complete STRING[bar] complete RIGHT_BRACE
```
```
write('{ "fo')
complete LEFT_BRACE, incomplete STRING[fo]

write('o')
incomplete STRING[foo]

write('": "')
complete STRING[foo], complete COLON, incomplete STRING[]
```

* An optimistic token parser expects tokens that are either complete or incomplete. On encoutering a complete token, the optimistic parser works as a normal parser. On encountering an incomplete token, the parser updates its internal state (e.g. adding a key to an object, or buffering a string), but _does not advance state_. This leaves the optimistic parser primed to accept more incomplete tokens or a complete token before actually moving on.
* Additionally, the optimistic parser (as presented in this PR) does not utiltise an `onValue`-style approach, instead offering the "top-level" value being parsed at all points (though this value will be mutated over the course of a parse). This allows consumers to write a chunk synchronously (as they do today) and observe the optimistic parse results directly.
* The optimistic JSON parser glues together the optimistic tokenizer and parser in the expected way.

# Details and comments

I appreciate this PR may offer functionality that is deemed out of scope or not in line with the implementations currently offered by this library -- if there are changes or improvements that would alter this, please let me know! If not, thank you very much for the lovely library and providing such a great base to build these features (which we are already using) on!

* I've extended the `README` to give a sense of the optimistic parsing support, but it might not be enough/might warrant its own piece of documentation.
* This PR does not yet include a NodeJS implementation of these features, though if this design makes sense/can be moulded into something agreeable I don't think it would be too much effort to add these.
* This PR includes a suite of tests for optimistic tokenizers and parsers, hopefully fairly in line with those already provided for features of the library.
* Optimistic parsers are a bit weaker than normal parsers in that they don't have the `paths` and `keepStack` options/don't emit nested values. If this is useful/required these features could likely be added back in. For a first implementation I removed them to make it simpler to work out how optimistic parsing could work.

Thanks again for reading this and the library as it stands today!