### PR TITLE
Fix path bug

### DIFF
--- a/packages/plainjs/src/tokenparser.ts
+++ b/packages/plainjs/src/tokenparser.ts
@@ -101,7 +101,7 @@ export default class TokenParser {
         const selector = path[i];
         const key = this.stack[i + 1].key;
         if (selector === "*") continue;
-        if (selector !== key) return false;
+        if (selector !== key?.toString()) return false;
       }
 
       const selector = path[path.length - 1];

--- a/packages/plainjs/test/selectors.ts
+++ b/packages/plainjs/test/selectors.ts
@@ -58,6 +58,8 @@ describe("selectors", () => {
           i += 1;
         },
       );
+
+      expect(i).toEqual(expected.length);
     });
   });
 

--- a/packages/plainjs/test/selectors.ts
+++ b/packages/plainjs/test/selectors.ts
@@ -39,6 +39,11 @@ describe("selectors", () => {
       paths: ["$.a.c.1"],
       expected: [4],
     },
+    {
+      value: '{ "a": [ {"b": 1}, {"c": 2} ] }',
+      paths: ["$.a.0.b"],
+      expected: [1],
+    },
   ];
 
   testData.forEach(({ value, paths, expected }) => {


### PR DESCRIPTION
Array-index based path parts were making the rest of the path to be ignored.

There's also a fix in the test runner for selectors, that had an issue in which it wasn't being ensured that the right number of elements were being emitted (I added a test case for this bug and it was being ignored because parser wasn't emitting anything).