### PR TITLE
Fix offset value when escape characters exist

### DIFF
--- a/packages/node/test/offset.ts
+++ b/packages/node/test/offset.ts
@@ -4,7 +4,8 @@ import TokenType from "@streamparser/json/utils/types/tokenType.js";
 
 const input1 = '{\n  "string": "value",\n  "number": 3,\n  "object"';
 const input2 = ': {\n  "key": "vд"\n  },\n  "array": [\n  -1,\n  12\n  ]\n  ';
-const input3 = '"null": null, "true": true, "false": false, "frac": 3.14 }';
+const input3 = '"null": null, "true": true, "false": false, "frac": 3.14,';
+const input4 = '"escape": "\\"\\u00e1" }';
 
 const offsets = [
   [0, TokenType.LEFT_BRACE],
@@ -46,7 +47,11 @@ const offsets = [
   [146, TokenType.STRING],
   [152, TokenType.COLON],
   [154, TokenType.NUMBER],
-  [159, TokenType.RIGHT_BRACE],
+  [158, TokenType.COMMA],
+  [159, TokenType.STRING],
+  [167, TokenType.COLON],
+  [169, TokenType.STRING],
+  [180, TokenType.RIGHT_BRACE],
 ];
 
 test("offset", async () => {
@@ -54,7 +59,7 @@ test("offset", async () => {
 
   await runTokenizerTest(
     new Tokenizer(),
-    [input1, input2, input3],
+    [input1, input2, input3, input4],
     ({ token, offset }) => {
       expect(offset).toEqual(offsets[i][0]);
       expect(token).toEqual(offsets[i][1]);

--- a/packages/plainjs/dist/deno/tokenizer.ts
+++ b/packages/plainjs/dist/deno/tokenizer.ts
@@ -110,6 +110,7 @@ export default class Tokenizer {
   private separator?: string;
   private separatorBytes?: Uint8Array;
   private separatorIndex = 0;
+  private escapeLength = 0;
   private bufferedString: StringBuilder;
   private bufferedNumber: StringBuilder;
 
@@ -336,6 +337,9 @@ export default class Tokenizer {
                 value: string,
                 offset: this.offset,
               });
+              this.offset += this.escapeLength;
+              this.escapeLength = 0;
+
               this.offset += this.bufferedString.byteLength + 1;
               continue;
             }
@@ -398,12 +402,14 @@ export default class Tokenizer {
             const controlChar = escapedSequences[n];
             if (controlChar) {
               this.bufferedString.appendChar(controlChar);
+              this.escapeLength += 1;
               this.state = TokenizerStates.STRING_DEFAULT;
               continue;
             }
 
             if (n === charset.LATIN_SMALL_LETTER_U) {
               this.unicode = "";
+              this.escapeLength += 4;
               this.state = TokenizerStates.STRING_UNICODE_DIGIT_1;
               continue;
             }

--- a/packages/plainjs/src/tokenizer.ts
+++ b/packages/plainjs/src/tokenizer.ts
@@ -110,6 +110,7 @@ export default class Tokenizer {
   private separator?: string;
   private separatorBytes?: Uint8Array;
   private separatorIndex = 0;
+  private escapeLength = 0;
   private bufferedString: StringBuilder;
   private bufferedNumber: StringBuilder;
 
@@ -336,6 +337,9 @@ export default class Tokenizer {
                 value: string,
                 offset: this.offset,
               });
+              this.offset += this.escapeLength;
+              this.escapeLength = 0;
+
               this.offset += this.bufferedString.byteLength + 1;
               continue;
             }
@@ -398,12 +402,14 @@ export default class Tokenizer {
             const controlChar = escapedSequences[n];
             if (controlChar) {
               this.bufferedString.appendChar(controlChar);
+              this.escapeLength += 1;
               this.state = TokenizerStates.STRING_DEFAULT;
               continue;
             }
 
             if (n === charset.LATIN_SMALL_LETTER_U) {
               this.unicode = "";
+              this.escapeLength += 4;
               this.state = TokenizerStates.STRING_UNICODE_DIGIT_1;
               continue;
             }

--- a/packages/plainjs/test/offset.ts
+++ b/packages/plainjs/test/offset.ts
@@ -4,7 +4,8 @@ import TokenType from "../src/utils/types/tokenType.js";
 
 const input1 = '{\n  "string": "value",\n  "number": 3,\n  "object"';
 const input2 = ': {\n  "key": "vд"\n  },\n  "array": [\n  -1,\n  12\n  ]\n  ';
-const input3 = '"null": null, "true": true, "false": false, "frac": 3.14 }';
+const input3 = '"null": null, "true": true, "false": false, "frac": 3.14,';
+const input4 = '"escape": "\\"\\u00e1" }';
 
 const offsets = [
   [0, TokenType.LEFT_BRACE],
@@ -46,7 +47,11 @@ const offsets = [
   [146, TokenType.STRING],
   [152, TokenType.COLON],
   [154, TokenType.NUMBER],
-  [159, TokenType.RIGHT_BRACE],
+  [158, TokenType.COMMA],
+  [159, TokenType.STRING],
+  [167, TokenType.COLON],
+  [169, TokenType.STRING],
+  [180, TokenType.RIGHT_BRACE],
 ];
 
 test("offset", async () => {
@@ -54,7 +59,7 @@ test("offset", async () => {
 
   await runTokenizerTest(
     new Tokenizer(),
-    [input1, input2, input3],
+    [input1, input2, input3, input4],
     ({ token, offset }) => {
       expect(offset).toEqual(offsets[i][0]);
       expect(token).toEqual(offsets[i][1]);

--- a/packages/whatwg/test/offset.ts
+++ b/packages/whatwg/test/offset.ts
@@ -4,7 +4,8 @@ import TokenType from "@streamparser/json/utils/types/tokenType.js";
 
 const input1 = '{\n  "string": "value",\n  "number": 3,\n  "object"';
 const input2 = ': {\n  "key": "vд"\n  },\n  "array": [\n  -1,\n  12\n  ]\n  ';
-const input3 = '"null": null, "true": true, "false": false, "frac": 3.14 }';
+const input3 = '"null": null, "true": true, "false": false, "frac": 3.14,';
+const input4 = '"escape": "\\"\\u00e1" }';
 
 const offsets = [
   [0, TokenType.LEFT_BRACE],
@@ -46,7 +47,11 @@ const offsets = [
   [146, TokenType.STRING],
   [152, TokenType.COLON],
   [154, TokenType.NUMBER],
-  [159, TokenType.RIGHT_BRACE],
+  [158, TokenType.COMMA],
+  [159, TokenType.STRING],
+  [167, TokenType.COLON],
+  [169, TokenType.STRING],
+  [180, TokenType.RIGHT_BRACE],
 ];
 
 test("offset", async () => {
@@ -54,7 +59,7 @@ test("offset", async () => {
 
   await runTokenizerTest(
     new Tokenizer(),
-    [input1, input2, input3],
+    [input1, input2, input3, input4],
     ({ token, offset }) => {
       expect(offset).toEqual(offsets[i][0]);
       expect(token).toEqual(offsets[i][1]);


### PR DESCRIPTION
Currently, the code assumes that 1 character in JSON corresponds to 1 character in the input. However, this isn't true because JSON supports escape characters (so multiple characters can map to a single JSON character)

![SHLOB](https://github.com/user-attachments/assets/7ed56f78-d3e8-4062-bd15-331a8c3cf130)

This PR fixes it, and adds tests for this case